### PR TITLE
Set up continuous acquisition mode in multiple acquisition examples

### DIFF
--- a/02-multiple-acquisition-callback.c
+++ b/02-multiple-acquisition-callback.c
@@ -83,10 +83,16 @@ main (int argc, char **argv)
 
 		printf ("Found camera '%s'\n", arv_camera_get_model_name (camera, NULL));
 
-		/* Create the stream object without callback */
+		arv_camera_set_acquisition_mode (camera, ARV_ACQUISITION_MODE_CONTINUOUS, &error);
+
 		callback_data.counter = 0;
 		callback_data.done = FALSE;
-		callback_data.stream = arv_camera_create_stream (camera, stream_callback, &callback_data, &error);
+		callback_data.stream = NULL;
+
+		if (error == NULL)
+			/* Create the stream object with callback */
+			callback_data.stream = arv_camera_create_stream (camera, stream_callback, &callback_data, &error);
+
 		if (ARV_IS_STREAM (callback_data.stream)) {
 			int i;
 			size_t payload;

--- a/02-multiple-acquisition-main-thread.c
+++ b/02-multiple-acquisition-main-thread.c
@@ -23,12 +23,16 @@ main (int argc, char **argv)
 	camera = arv_camera_new (NULL, &error);
 
 	if (ARV_IS_CAMERA (camera)) {
-		ArvStream *stream;
+		ArvStream *stream = NULL;
 
 		printf ("Found camera '%s'\n", arv_camera_get_model_name (camera, NULL));
 
-		/* Create the stream object without callback */
-		stream = arv_camera_create_stream (camera, NULL, NULL, &error);
+		arv_camera_set_acquisition_mode (camera, ARV_ACQUISITION_MODE_CONTINUOUS, &error);
+
+		if (error == NULL)
+			/* Create the stream object without callback */
+			stream = arv_camera_create_stream (camera, NULL, NULL, &error);
+
 		if (ARV_IS_STREAM (stream)) {
 			int i;
 			size_t payload;

--- a/02-multiple-acquisition-signal.c
+++ b/02-multiple-acquisition-signal.c
@@ -57,12 +57,16 @@ main (int argc, char **argv)
 	camera = arv_camera_new (NULL, &error);
 
 	if (ARV_IS_CAMERA (camera)) {
-		ArvStream *stream;
+		ArvStream *stream = NULL;
 
 		printf ("Found camera '%s'\n", arv_camera_get_model_name (camera, NULL));
 
-		/* Create the stream object without callback */
-		stream = arv_camera_create_stream (camera, NULL, NULL, &error);
+		arv_camera_set_acquisition_mode (camera, ARV_ACQUISITION_MODE_CONTINUOUS, &error);
+
+		if (error == NULL)
+			/* Create the stream object without callback */
+			stream = arv_camera_create_stream (camera, NULL, NULL, &error);
+
 		if (ARV_IS_STREAM (stream)) {
 			int i;
 			size_t payload;


### PR DESCRIPTION
I think it is relevant to include the camera acquisition mode config in these examples as it is something one would need to take care when implementing a logic related to multiple frame acquisition in their application.

I don't know if this operation mode is widely supported by the cameras, though. I've assumed it is.